### PR TITLE
GitHub Actions の action version を更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           sudo locale-gen ${LANG}
           sudo update-locale LANG=${LANG}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
## 概要
GitHub Actions で使用している action のバージョンを更新します。

## 変更内容
- actions/checkout@v3 → @v6
- actions/setup-java@v3 → @v5

## 背景
Actions 実行時に Node.js 20 非推奨の warning が表示されていたため、現行の major version に更新します。

## 確認事項
- GitHub Actions が正常に実行されること
- 既存の CI が緑になること

Closes #1