### PR TITLE
CIのJava対象を8以降の全LTSに拡張

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
           - 8
           - 11
           - 17
+          - 21
+          - 25
 
     steps:
       - name: Set locale


### PR DESCRIPTION
## 概要
GitHub Actions の CI で実行する Java バージョンを、8以降の全LTSに拡張します。

## 変更内容
- matrix.java に 21 を追加
- matrix.java に 25 を追加

## 背景
現在の CI は Java 8 / 11 / 17 を対象としているため、8以降の全LTSを継続的に確認できるようにします。

## 確認事項
- GitHub Actions が正常に実行されること
- JDK 8 / 11 / 17 / 21 / 25 の各ジョブが作成されること
- 既存の CI が緑になること

Closes #3 