### PR TITLE
Dependabot の version updates(Maven / GitHub Actions)を設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## 概要

Dependabot の version updates 設定を追加します。

## 変更内容

- `.github/dependabot.yml` を追加
- Maven を対象に設定
- GitHub Actions を対象に設定

Closes #7 